### PR TITLE
Add MultiTouchBlink examples

### DIFF
--- a/examples/MultiTouchBlink_IRQ/MultiTouchBlink_IRQ.ino
+++ b/examples/MultiTouchBlink_IRQ/MultiTouchBlink_IRQ.ino
@@ -1,0 +1,61 @@
+/* 
+ * MultiTouchBlink_IRQ.ino
+ * 
+ * This example shows how to visualise the number of touch points, using the RGB LED. 
+ * 
+ * Whenever a touch event is detected, gigaTouchHandler() records the number of touches and blinks the RGB LED accordingly.
+ * The event is also detected and sent via Serial. The touch handler is detached, blink is performed and then re-attached.
+ *  
+ * For the polling version of this example, see MultiTouchBlink_IRQ.ino
+ * 
+ * Instructions:
+ * 1. Connect your GIGA Display Shield (ASX00039) to a GIGA R1 WiFi (ABX00063) board.
+ * 2. Upload this sketch to your board.
+ * 3. Open the Serial Monitor.
+ * 4. Touch the screen with your finger(s).
+ * 5. The LED will blink, based on how many touch contact are recorded. Note that fingers need to be placed all at the same time. 
+ * 
+ * Initial author: Ali Jahangiri @aliphys
+ * Created: 12 June 2024
+ */
+
+#include "Arduino_GigaDisplayTouch.h"
+
+Arduino_GigaDisplayTouch touchDetector;
+
+int contactPoints = 0;
+
+void gigaTouchHandler(uint8_t contacts, GDTpoint_t* points) {
+  contactPoints = contacts;
+  touchDetector.end();  // close the touch controller
+}
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {}
+
+  if (touchDetector.begin()) {
+    Serial.println("Touch controller init - OK");
+  } else {
+    Serial.println("Touch controller init - FAILED");
+    while (1);
+  }
+
+  touchDetector.onDetect(gigaTouchHandler);
+}
+
+void loop() {
+  if (contactPoints > 0) {
+    Serial.println("Contact Detected! Will Blink " + String(contactPoints) + " times!");
+    for (int i = 0; i < contactPoints; i++) {
+      digitalWrite(LED_BUILTIN, LOW);
+      delay(250);
+      digitalWrite(LED_BUILTIN, HIGH);
+      delay(250);
+    }
+    contactPoints = 0;
+    touchDetector.begin();
+    delay(100);
+    touchDetector.onDetect(gigaTouchHandler);
+  }
+}

--- a/examples/MultiTouchBlink_Polling/MultiTouchBlink_Polling.ino
+++ b/examples/MultiTouchBlink_Polling/MultiTouchBlink_Polling.ino
@@ -34,7 +34,7 @@ void setup() {
     Serial.println("Touch controller init - OK");
   } else {
     Serial.println("Touch controller init - FAILED");
-    while (1)
+    while (1) ;
   }
 }
 

--- a/examples/MultiTouchBlink_Polling/MultiTouchBlink_Polling.ino
+++ b/examples/MultiTouchBlink_Polling/MultiTouchBlink_Polling.ino
@@ -35,7 +35,6 @@ void setup() {
   } else {
     Serial.println("Touch controller init - FAILED");
     while (1)
-      ;
   }
 }
 

--- a/examples/MultiTouchBlink_Polling/MultiTouchBlink_Polling.ino
+++ b/examples/MultiTouchBlink_Polling/MultiTouchBlink_Polling.ino
@@ -1,0 +1,62 @@
+/* 
+ * MultiTouchBlink_Polling.ino
+ * 
+ * This example shows how to visualise the number of touch points, using the RGB LED. 
+ * 
+ * On each iteration of the loop, the touch points are obtained from the GT911 controller. If the touch points exist, then a message
+ * is sent to the Serial, and the LED is blinked the corresponding number of times. A 1 second delay is given after a touch is detected, to
+ * act as a basic debounce utility.  
+ *  
+ * For the interrupt version of this example, see MultiTouchBlink_IRQ.ino
+ * 
+ * Instructions:
+ * 1. Connect your GIGA Display Shield (ASX00039) to a GIGA R1 WiFi (ABX00063) board.
+ * 2. Upload this sketch to your board.
+ * 3. Open the Serial Monitor.
+ * 4. Touch the screen with your finger(s).
+ * 5. The LED will blink, based on how many touch contact are recorded. Note that fingers need to be placed all at the same time. 
+ * 
+ * Initial author: Ali Jahangiri @aliphys
+ * Created: 12 June 2024
+ */
+
+#include "Arduino_GigaDisplayTouch.h"
+
+Arduino_GigaDisplayTouch touchDetector;
+
+int contactPoints = 0;
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial) {}
+
+  if (touchDetector.begin()) {
+    Serial.println("Touch controller init - OK");
+  } else {
+    Serial.println("Touch controller init - FAILED");
+    while (1)
+      ;
+  }
+}
+
+void loop() {
+  uint8_t contacts;
+  GDTpoint_t points[5];
+  contactPoints = 0;
+
+  contactPoints = touchDetector.getTouchPoints(points);
+
+  if (contactPoints > 0) {
+    Serial.println("Contact Detected! Will Blink " + String(contactPoints) + " times!");
+    for (int i = 1; i <= contactPoints; i++) {
+      digitalWrite(LED_BUILTIN, LOW);
+      delay(250);
+      digitalWrite(LED_BUILTIN, HIGH);
+      delay(250);
+    }
+
+    delay(1000);
+  }
+
+  delay(1);
+}


### PR DESCRIPTION
This PR adds two examples, that blinks the LED on the GIGA R1 WiFi based on the number of touches registered on the screen. 
- ⁉️ MultiTouchBlink_IRQ.ino shows how to attach and detach an interrupt (be calling `touchDetector.begin();`
- 🚥 The LED onboard the GIGA R1 WiFi is used to display the feedback from the touch events. Using the RGB LED on the GIGA Display Shield itself would create a cyclical dependency since the [GIGADisplayRGB](https://github.com/arduino-libraries/Arduino_GigaDisplay/blob/6536ab589056b343705c030c2ea1e21a986e1a36/src/GigaDisplayRGB.h) class is part of [arduino-libraries/Arduino_GigaDisplay](https://github.com/arduino-libraries/Arduino_GigaDisplay)
- 🌐 Both interrupt `MultiTouchBlink_IRQ.ino` and polling approaches `MultiTouchBlink_Polling.ino` are covered. 

✨ Thanks for initial testing and feedback by @Hannes7eicher and @pedromsousalima
Closes https://github.com/arduino-libraries/Arduino_GigaDisplayTouch/issues/10