### PR TITLE
Preliminary Giga Touch support on Zephyr

### DIFF
--- a/src/Arduino_GigaDisplayTouch.h
+++ b/src/Arduino_GigaDisplayTouch.h
@@ -30,9 +30,11 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "Wire.h"
+#include <Arduino.h>
+#ifdef __MBED__
 #include "mbed.h"
 #include "pinDefinitions.h"
-#include <Arduino.h>
+#endif
 
 /* Exported defines ----------------------------------------------------------*/
 #define GT911_I2C_ADDR_BA_BB (0x5D | 0x80) // 0xBA/0xBB - 0x5D (7bit address)
@@ -69,16 +71,18 @@ struct GDTpoint_s {
  */
 class Arduino_GigaDisplayTouch {
 public:
-/**
- * @brief Construct a new touch controller for Giga Display Shield.
- *
- * @param wire A reference to the Wire interface to be used for communication
- * with the touch controller.
- * @param intPin The interrupt pin number for the touch controller.
- * @param rstPin The reset pin number for the touch controller.
- * @param addr The device address for the touch controller.
- */
-#if defined(ARDUINO_GIGA)
+  /**
+   * @brief Construct a new touch controller for Giga Display Shield.
+   *
+   * @param wire A reference to the Wire interface to be used for communication
+   * with the touch controller.
+   * @param intPin The interrupt pin number for the touch controller.
+   * @param rstPin The reset pin number for the touch controller.
+   * @param addr The device address for the touch controller.
+   */
+#if defined(__ZEPHYR__)
+  Arduino_GigaDisplayTouch();
+#elif defined(ARDUINO_GIGA)
   Arduino_GigaDisplayTouch(TwoWire &wire = Wire1,
                            uint8_t intPin = PinNameToIndex(PI_1),
                            uint8_t rstPin = PinNameToIndex(PI_2),
@@ -92,6 +96,7 @@ public:
   Arduino_GigaDisplayTouch(TwoWire &wire, uint8_t intPin, uint8_t rstPin,
                            uint8_t addr);
 #endif
+
   ~Arduino_GigaDisplayTouch();
 
   /**
@@ -121,11 +126,12 @@ public:
   void onDetect(void (*handler)(uint8_t, GDTpoint_t *));
 
 private:
+#if defined(__MBED__)
   TwoWire &_wire;
   uint8_t _intPin;
-  mbed::InterruptIn _irqInt;
   uint8_t _rstPin;
   uint8_t _addr;
+  mbed::InterruptIn _irqInt;
   GDTpoint_t _points[GT911_MAX_CONTACTS];
   void (*_gt911TouchHandler)(uint8_t, GDTpoint_t *);
 
@@ -134,6 +140,8 @@ private:
   uint8_t _gt911ReadOp(uint16_t reg, uint8_t *data, uint8_t len);
   void _gt911onIrq();
   uint8_t _gt911ReadInputCoord(uint8_t *pointsbuf, uint8_t &contacts);
+
+#endif
 };
 
 #endif /* __ARDUINO_GIGADISPLAYTOUCH_H */

--- a/src/Arduino_GigaDisplayTouchMbed.cpp
+++ b/src/Arduino_GigaDisplayTouchMbed.cpp
@@ -23,6 +23,7 @@
  */
 
 /* Includes -----------------------------------------------------------------*/
+#ifdef __MBED__
 #include "Arduino_GigaDisplayTouch.h"
 
 #if __has_include("lvgl.h")
@@ -281,4 +282,5 @@ uint8_t Arduino_GigaDisplayTouch::_gt911ReadInputCoord(uint8_t *pointsbuf,
   return 0;
 }
 
-/**** END OF FILE ****/
+#endif /* __MBED__ */
+       /**** END OF FILE ****/

--- a/src/Arduino_GigaDisplayTouchZephyr.cpp
+++ b/src/Arduino_GigaDisplayTouchZephyr.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2025 Arduino SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#ifdef __ZEPHYR__
+
+#include "Arduino_GigaDisplayTouch.h"
+#include <zephyr/device.h>
+#include <zephyr/drivers/display.h>
+#include <zephyr/input/input.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+
+typedef struct {
+  size_t x;
+  size_t y;
+  bool pressed;
+} touch_point_t;
+
+static uint8_t zephyr_touch_cb_slot_num;
+static struct k_sem zephyr_touch_event_sync;
+static touch_point_t zephyr_touch_points[CONFIG_INPUT_GT911_MAX_TOUCH_POINTS];
+
+typedef void (*zephyr_input_callback_t)(struct input_event *evt,
+                                        void *user_data);
+extern "C" void zephyr_input_register_callback(zephyr_input_callback_t cb);
+static void touch_event_callback(struct input_event *evt, void *user_data);
+
+Arduino_GigaDisplayTouch::Arduino_GigaDisplayTouch() {}
+
+Arduino_GigaDisplayTouch::~Arduino_GigaDisplayTouch() {}
+
+bool Arduino_GigaDisplayTouch::begin() {
+  k_sem_init(&zephyr_touch_event_sync, 0, 1);
+  zephyr_input_register_callback(touch_event_callback);
+  return true;
+}
+
+void Arduino_GigaDisplayTouch::end() {}
+
+uint8_t Arduino_GigaDisplayTouch::getTouchPoints(GDTpoint_t *points) {
+  // First wait to see if we get any events.
+  if (k_sem_take(&zephyr_touch_event_sync, K_NO_WAIT) != 0) {
+    return 0;
+  }
+
+  uint8_t count_pressed = 0;
+  for (uint8_t i = 0; i <= zephyr_touch_cb_slot_num; i++) {
+    if (zephyr_touch_points[i].pressed) {
+      points[count_pressed].x = zephyr_touch_points[i].x;
+      points[count_pressed].y = zephyr_touch_points[i].y;
+      count_pressed++;
+    }
+  }
+  return count_pressed;
+}
+
+void Arduino_GigaDisplayTouch::onDetect(void (*handler)(uint8_t,
+                                                        GDTpoint_t *)) {
+  UNUSED(handler);
+}
+
+static void touch_event_callback(struct input_event *evt, void *user_data) {
+  static const struct device *const touch_dev =
+      DEVICE_DT_GET(DT_CHOSEN(zephyr_touch));
+
+  if (evt->dev != touch_dev) {
+    return;
+  }
+
+  switch (evt->code) {
+  case INPUT_ABS_MT_SLOT:
+    zephyr_touch_cb_slot_num = evt->value;
+    break;
+  case INPUT_ABS_X:
+    zephyr_touch_points[zephyr_touch_cb_slot_num].x = evt->value;
+    break;
+  case INPUT_ABS_Y:
+    zephyr_touch_points[zephyr_touch_cb_slot_num].y = evt->value;
+    break;
+  case INPUT_BTN_TOUCH:
+    zephyr_touch_points[zephyr_touch_cb_slot_num].pressed = evt->value;
+    break;
+  }
+
+  if (evt->sync) {
+    k_sem_give(&zephyr_touch_event_sync);
+  }
+}
+#endif


### PR DESCRIPTION
Zephyr: Added in our preliminary support for touch on the display

In ArduinoCore-zephyr added a callback to register with the input class.  When set it simply forwards the callbacks to this function.

Then added some support.  We still don't have things like gestures as I don't think the zephyr input class has support for it.

Have a simple touch paint sketch (now supporting multiple touches, that appears to work

Depends on:
- [x] https://github.com/arduino-libraries/Arduino_GigaDisplayTouch/pull/15
- [x] https://github.com/arduino/ArduinoCore-zephyr/pull/165
