### PR TITLE
Zephyr - Add call to (void)zephyr::arduino::init_dev_apply_pinctrl(dev)

### DIFF
--- a/src/Arduino_GigaDisplayTouch.h
+++ b/src/Arduino_GigaDisplayTouch.h
@@ -87,6 +87,7 @@ public:
    */
 #if defined(__ZEPHYR__)
   Arduino_GigaDisplayTouch();
+  Arduino_GigaDisplayTouch(TwoWire &wire);
 #elif defined(ARDUINO_GIGA)
   Arduino_GigaDisplayTouch(TwoWire &wire = Wire1,
                            uint8_t intPin = PinNameToIndex(PI_1),
@@ -133,8 +134,8 @@ public:
 private:
   GDTTouchHandler_t _gt911TouchHandler;
   GDTpoint_t _points[GT911_MAX_CONTACTS];
-#if defined(__MBED__)
   TwoWire &_wire;
+#if defined(__MBED__)
   uint8_t _intPin;
   uint8_t _rstPin;
   uint8_t _addr;

--- a/src/Arduino_GigaDisplayTouchZephyr.cpp
+++ b/src/Arduino_GigaDisplayTouchZephyr.cpp
@@ -32,23 +32,39 @@ extern "C" void zephyr_input_register_callback(zephyr_input_callback_t cb,
                                                void *user_data);
 void touch_event_callback(struct input_event *evt, void *user_data);
 
-Arduino_GigaDisplayTouch::Arduino_GigaDisplayTouch() {}
+Arduino_GigaDisplayTouch::Arduino_GigaDisplayTouch()
+    : Arduino_GigaDisplayTouch(Wire1) {}
+
+Arduino_GigaDisplayTouch::Arduino_GigaDisplayTouch(TwoWire &wire)
+    : _wire{wire} {}
 
 Arduino_GigaDisplayTouch::~Arduino_GigaDisplayTouch() {}
 
 bool Arduino_GigaDisplayTouch::begin() {
-  static const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_touch));
+  static const struct device *const dev =
+      DEVICE_DT_GET(DT_CHOSEN(zephyr_touch));
   if (!dev) {
     printk("<ERR> touch DEV null\n");
     return false;
   }
-  (void)zephyr::arduino::init_dev_apply_pinctrl(dev);
+
+  _wire.begin();
+
+  if (!device_is_ready(dev)) {
+    // init device for first usage, if not ready
+    int err = device_init(dev);
+    if (err < 0) {
+      return false;
+    }
+  }
 
   _gt911TouchHandler = nullptr;
+
   // Initialize to 1 to prevent deadlock by ensuring that
   // at least one function can always proceed initially.
   k_sem_init(&touch_sem, 1, 1);
   zephyr_input_register_callback(touch_event_callback, this);
+
   return true;
 }
 

--- a/src/Arduino_GigaDisplayTouchZephyr.cpp
+++ b/src/Arduino_GigaDisplayTouchZephyr.cpp
@@ -37,6 +37,13 @@ Arduino_GigaDisplayTouch::Arduino_GigaDisplayTouch() {}
 Arduino_GigaDisplayTouch::~Arduino_GigaDisplayTouch() {}
 
 bool Arduino_GigaDisplayTouch::begin() {
+  static const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_touch));
+  if (!dev) {
+    printk("<ERR> touch DEV null\n");
+    return false;
+  }
+  (void)zephyr::arduino::init_dev_apply_pinctrl(dev);
+
   _gt911TouchHandler = nullptr;
   // Initialize to 1 to prevent deadlock by ensuring that
   // at least one function can always proceed initially.


### PR DESCRIPTION
Note: this is for the not yet released zephyr builds that include enhanced pin control handling.

Note: this is still not sufficient to get the touch code working with current sources, see the issue: https://github.com/arduino/ArduinoCore-zephyr/issues/488